### PR TITLE
Adjust MQTT connection timeout logic

### DIFF
--- a/rizeni_teploty_kotel.ino
+++ b/rizeni_teploty_kotel.ino
@@ -233,7 +233,7 @@ void MQTTConnect()
         exponent = 0.76923;
         insideTemperature = 22.5;
         mqttLastConnectionTry = currentMillis;
-        mqttConnectionTimeout = min(mqttConnectionTimeout + random(5000, 30000), 300000);
+        mqttConnectionTimeout = min(mqttConnectionTimeout * 2 + random(0, 5000), 300000);
       }
     }
   }


### PR DESCRIPTION
Changed the MQTT connection timeout calculation to double the previous timeout and add a random delay, instead of incrementing by a random value. This may improve reconnection backoff behavior.