### PR TITLE
Fix temperature input reference in heating logic

### DIFF
--- a/rizeni_teploty_kotel.ino
+++ b/rizeni_teploty_kotel.ino
@@ -506,11 +506,11 @@ bool ShouldBeHeatingOff()
   }
   if(currentState.mode == AUTOMATIC)
   {
-    return currentState.currentTemp < MININPUTTEMPERATURE;
+    return currentState.inputTemp < MININPUTTEMPERATURE;
   }
   if(currentState.mode == THERMOSTAT)
   {
-    return !thermostat || currentState.currentTemp < MININPUTTEMPERATURE;
+    return !thermostat || currentState.inputTemp < MININPUTTEMPERATURE;
   }
   return false;
 }
@@ -523,11 +523,11 @@ bool ShouldBeHeatingOn()
   }
   if(currentState.mode == AUTOMATIC)
   {
-    return currentState.currentTemp > MININPUTTEMPERATURE + 1;
+    return currentState.inputTemp > MININPUTTEMPERATURE + 1;
   }
   if(currentState.mode == THERMOSTAT)
   {
-    return thermostat && currentState.currentTemp > MININPUTTEMPERATURE + 1;
+    return thermostat && currentState.inputTemp > MININPUTTEMPERATURE + 1;
   }
   return false;
 }


### PR DESCRIPTION
Replaced incorrect usage of currentTemp with inputTemp in ShouldBeHeatingOff and ShouldBeHeatingOn functions to ensure correct temperature readings are used for heating control decisions.