### PR TITLE
Add diagnostics reporting and sensor error handling

### DIFF
--- a/HeatingTemperatureRegulator.ino
+++ b/HeatingTemperatureRegulator.ino
@@ -106,13 +106,13 @@ struct FVEData
 };
 
 struct DiagData {
-  uint8_t uptime[4];
-  uint8_t freeRam[4];
-  uint8_t wifiReconn[4];
-  uint8_t mqttReconn[4];
-  uint8_t sensorErr;
-  uint8_t resetReason;
-  uint8_t loopMaxMs[4];
+  uint32_t uptime;
+  uint16_t freeRam;
+  uint16_t wifiReconn;
+  uint16_t mqttReconn;
+  uint16_t sensorErr;
+  uint8_t  resetReason;
+  uint16_t loopMaxMs;
 };
 #pragma pack(pop)
 
@@ -179,9 +179,6 @@ unsigned long heaterStartTimeoutBegin = 0;
 bool checkHeaterStartTimeout = false;
 unsigned long lastWasteGasReadMillis = 0;
 unsigned short wasteGasGradientCount = 0;
-uint16_t wifiReconnectCount = 0;
-uint16_t mqttReconnectCount = 0;
-uint32_t maxLoopTime = 0;
 
 int freeRam() {
   extern int __heap_start, *__brkval;
@@ -244,9 +241,9 @@ void MQTTConnect()
   if(wifiStatus == WL_DISCONNECTED || wifiStatus == WL_IDLE_STATUS)
   {
     wifiConnected = drv.Connect(WifiSSID, WifiPassword);
-    if(wifiReconnectCount < 65535) 
+    if(currentDiagData.wifiReconn < 65535)
     {
-      wifiReconnectCount++;
+      currentDiagData.wifiReconn++;
     }
     mqttLastConnectionTry = currentMillis;
   }
@@ -256,9 +253,9 @@ void MQTTConnect()
     if(!isConnected)
     {
       Serial.println("Connect");
-      if(mqttReconnectCount < 65535) 
+      if(currentDiagData.mqttReconn < 65535)
       {
-        mqttReconnectCount++;
+        currentDiagData.mqttReconn++;
       }
       if(client.Connect(mqttConnectData))
       {
@@ -702,15 +699,12 @@ void readCurrentHeatingTemperature()
 unsigned int sendIndex = 0;
 void sendDiag()
 {
-  convertToHalfByte((int)(currentMillis / 60000), currentDiagData.uptime, 4);
-  convertToHalfByte(freeRam(), currentDiagData.freeRam, 4);
-  convertToHalfByte(wifiReconnectCount, currentDiagData.wifiReconn, 4);
-  convertToHalfByte(mqttReconnectCount, currentDiagData.mqttReconn, 4);
-  convertToHalfByte((int)maxLoopTime, currentDiagData.loopMaxMs, 4);
+  currentDiagData.uptime = currentMillis / 60000;
+  currentDiagData.freeRam = freeRam();
   uint8_t buffer[sizeof(DiagData)];
   memcpy(buffer, &currentDiagData, sizeof(DiagData));
   client.Publish(TOPIC_DIAG, buffer, sizeof(DiagData), false);
-  maxLoopTime = 0;
+  currentDiagData.loopMaxMs = 0;
   currentDiagData.sensorErr = 0;
   Serial.println("Diag publish");
 }
@@ -745,7 +739,7 @@ void sendToHomeAssistant()
   bit 5 - acumulator4
   bit 6 - returnHeating
   bit 7 - heater
-  Boiler se nevejde do 8 bitů, ale je nejméně kritický.
+  bit 8 - boiler
 */
 void sendHeaterToHomeAssistant()
 {
@@ -773,7 +767,10 @@ void sendHeaterToHomeAssistant()
   {
     currentDiagData.sensorErr |= (1 << 7);
   }
-  tempSensors.GetBoilerTemperature(&currentState.boilerTemp);
+  if(!tempSensors.GetBoilerTemperature(&currentState.boilerTemp))
+  {
+    currentDiagData.sensorErr |= (1 << 8);
+  }
   convertToHalfByte((int)slowAverageWasteGasTemperature, currentState.wasteGasTemp, 4);
   uint8_t buffer[sizeof(HeaterState)];
   memcpy(buffer, &currentState, sizeof(HeaterState));
@@ -926,6 +923,9 @@ void loop() {
     }
     lastRegulatorMeasurement  = currentMillis;
   }
-  uint32_t loopElapsed = millis() - currentMillis;
-  if(loopElapsed > maxLoopTime) maxLoopTime = loopElapsed;
+  uint16_t loopElapsed = millis() - currentMillis;
+  if(loopElapsed > currentDiagData.loopMaxMs)
+  {
+    currentDiagData.loopMaxMs = loopElapsed;
+  }
 }

--- a/HeatingTemperatureRegulator.ino
+++ b/HeatingTemperatureRegulator.ino
@@ -104,11 +104,22 @@ struct FVEData
   uint8_t power[4];
   uint8_t consumption[4];
 };
+
+struct DiagData {
+  uint8_t uptime[4];
+  uint8_t freeRam[4];
+  uint8_t wifiReconn[4];
+  uint8_t mqttReconn[4];
+  uint8_t sensorErr;
+  uint8_t resetReason;
+  uint8_t loopMaxMs[4];
+};
 #pragma pack(pop)
 
 HeaterState currentState;
 
 FVEData currentFveData;
+DiagData currentDiagData;
 BelData belData;
 
 uint8_t temperatureDataToCompare[5];
@@ -133,6 +144,7 @@ uint32_t relayOffMillis = 0;
 uint32_t currentMillis = 0;
 uint32_t temperatureReadMillis = 0;
 uint32_t lastMQTTSendMillis = 0;
+uint32_t lastDiagSendMillis = 0;
 uint32_t lastRegulatorMeasurement  = 0;
 long interval = 0;
 long position = SERVOMAXRANGE;
@@ -167,8 +179,19 @@ unsigned long heaterStartTimeoutBegin = 0;
 bool checkHeaterStartTimeout = false;
 unsigned long lastWasteGasReadMillis = 0;
 unsigned short wasteGasGradientCount = 0;
+uint16_t wifiReconnectCount = 0;
+uint16_t mqttReconnectCount = 0;
+uint32_t maxLoopTime = 0;
+
+int freeRam() {
+  extern int __heap_start, *__brkval;
+  int v;
+  return (int)&v - (__brkval == 0 ? (int)&__heap_start : (int)__brkval);
+}
 
 void setup() {
+  currentDiagData.resetReason = MCUSR;
+  MCUSR = 0;
   Serial.begin(57600);
   //AT+UART_DEF=57600,8,1,0,0
   Serial1.begin(57600);
@@ -221,6 +244,10 @@ void MQTTConnect()
   if(wifiStatus == WL_DISCONNECTED || wifiStatus == WL_IDLE_STATUS)
   {
     wifiConnected = drv.Connect(WifiSSID, WifiPassword);
+    if(wifiReconnectCount < 65535) 
+    {
+      wifiReconnectCount++;
+    }
     mqttLastConnectionTry = currentMillis;
   }
   if(wifiConnected)
@@ -229,6 +256,10 @@ void MQTTConnect()
     if(!isConnected)
     {
       Serial.println("Connect");
+      if(mqttReconnectCount < 65535) 
+      {
+        mqttReconnectCount++;
+      }
       if(client.Connect(mqttConnectData))
       {
         Serial.println("Subscribes");
@@ -639,7 +670,10 @@ void checkHeating()
 void readInputTemperature()
 {
   uint8_t newInputTemperature = currentState.inputTemp;
-  tempSensors.GetAcumulatorOutputTemperature(&newInputTemperature);
+  if(!tempSensors.GetAcumulatorOutputTemperature(&newInputTemperature))
+  {
+    currentDiagData.sensorErr |= (1 << 1);
+  }
   if(currentState.inputTemp != newInputTemperature)
   { 
     lcd.SetInputTemperature(newInputTemperature);
@@ -650,7 +684,10 @@ void readInputTemperature()
 void readCurrentHeatingTemperature()
 {
   uint8_t newCelsius = currentState.currentTemp;
-  tempSensors.GetCurrentHeatingTemperature(&newCelsius);
+  if(!tempSensors.GetCurrentHeatingTemperature(&newCelsius))
+  {
+    currentDiagData.sensorErr |= (1 << 0);
+  }
   if(newCelsius > 100)
   {
     return;
@@ -663,6 +700,21 @@ void readCurrentHeatingTemperature()
 }
 
 unsigned int sendIndex = 0;
+void sendDiag()
+{
+  convertToHalfByte((int)(currentMillis / 60000), currentDiagData.uptime, 4);
+  convertToHalfByte(freeRam(), currentDiagData.freeRam, 4);
+  convertToHalfByte(wifiReconnectCount, currentDiagData.wifiReconn, 4);
+  convertToHalfByte(mqttReconnectCount, currentDiagData.mqttReconn, 4);
+  convertToHalfByte((int)maxLoopTime, currentDiagData.loopMaxMs, 4);
+  uint8_t buffer[sizeof(DiagData)];
+  memcpy(buffer, &currentDiagData, sizeof(DiagData));
+  client.Publish(TOPIC_DIAG, buffer, sizeof(DiagData), false);
+  maxLoopTime = 0;
+  currentDiagData.sensorErr = 0;
+  Serial.println("Diag publish");
+}
+
 void sendToHomeAssistant()
 {
   if(currentMillis - lastMQTTSendMillis > 30000)
@@ -683,14 +735,44 @@ void sendToHomeAssistant()
   }
 }
 
+/*
+  sensorErr bitová mapa:
+  bit 0 - currentHeating
+  bit 1 - acumulatorOutput (inputTemp)
+  bit 2 - acumulator1
+  bit 3 - acumulator2
+  bit 4 - acumulator3
+  bit 5 - acumulator4
+  bit 6 - returnHeating
+  bit 7 - heater
+  Boiler se nevejde do 8 bitů, ale je nejméně kritický.
+*/
 void sendHeaterToHomeAssistant()
 {
-  tempSensors.GetAcumulator1Temperature(&currentState.acum1);
-  tempSensors.GetAcumulator2Temperature(&currentState.acum2);
-  tempSensors.GetAcumulator3Temperature(&currentState.acum3);
-  tempSensors.GetAcumulator4Temperature(&currentState.acum4);
-  tempSensors.GetReturnHeatingTemperature(&currentState.returnTemp);
-  tempSensors.GetHeaterTemperature(&currentState.heaterTemp);
+  if(!tempSensors.GetAcumulator1Temperature(&currentState.acum1))
+  {
+    currentDiagData.sensorErr |= (1 << 2);
+  }
+  if(!tempSensors.GetAcumulator2Temperature(&currentState.acum2))
+  {
+    currentDiagData.sensorErr |= (1 << 3);
+  }
+  if(!tempSensors.GetAcumulator3Temperature(&currentState.acum3))
+  {
+    currentDiagData.sensorErr |= (1 << 4);
+  }
+  if(!tempSensors.GetAcumulator4Temperature(&currentState.acum4))
+  {
+    currentDiagData.sensorErr |= (1 << 5);
+  }
+  if(!tempSensors.GetReturnHeatingTemperature(&currentState.returnTemp))
+  {
+    currentDiagData.sensorErr |= (1 << 6);
+  }
+  if(!tempSensors.GetHeaterTemperature(&currentState.heaterTemp))
+  {
+    currentDiagData.sensorErr |= (1 << 7);
+  }
   tempSensors.GetBoilerTemperature(&currentState.boilerTemp);
   convertToHalfByte((int)slowAverageWasteGasTemperature, currentState.wasteGasTemp, 4);
   uint8_t buffer[sizeof(HeaterState)];
@@ -770,8 +852,9 @@ void CheckHeaterStartTimeout()
 }
 
 void loop() {
-  wdt_reset();
   currentMillis = millis();
+  wdt_reset();
+  
   if(!client.Loop())
   {
     MQTTConnect();
@@ -800,6 +883,11 @@ void loop() {
   SetHeatingTemperatureByOverheating();
   lcd.Print();
   sendToHomeAssistant();
+  if(currentMillis - lastDiagSendMillis > 300000)
+  {
+    sendDiag();
+    lastDiagSendMillis = currentMillis;
+  }
   if(!relayOn)
   {
     checkHeating();    
@@ -838,4 +926,6 @@ void loop() {
     }
     lastRegulatorMeasurement  = currentMillis;
   }
+  uint32_t loopElapsed = millis() - currentMillis;
+  if(loopElapsed > maxLoopTime) maxLoopTime = loopElapsed;
 }

--- a/TemperatureSensors.cpp
+++ b/TemperatureSensors.cpp
@@ -25,7 +25,6 @@ void TemperatureSensors::Init()
     Serial.println(temp);
   }
   this->sensors->setResolution(currentHeating, 12);
-  this->sensors->setWaitForConversion(false);
 }
 
 void TemperatureSensors::RequestTemperatures()

--- a/TemperatureSensors.cpp
+++ b/TemperatureSensors.cpp
@@ -25,6 +25,7 @@ void TemperatureSensors::Init()
     Serial.println(temp);
   }
   this->sensors->setResolution(currentHeating, 12);
+  this->sensors->setWaitForConversion(false);
 }
 
 void TemperatureSensors::RequestTemperatures()

--- a/TemperatureSensors.cpp
+++ b/TemperatureSensors.cpp
@@ -80,7 +80,7 @@ bool TemperatureSensors::GetCurrentHeatingTemperature(uint8_t* temperature)
 bool TemperatureSensors::GetTemperature(DeviceAddress deviceAddress, uint8_t* temperature)
 {
   float temp = sensors->getTempC(deviceAddress);
-  if(temp <= -127.0f || temp < 0 || temp > 120)
+  if(temp < 0 || temp > 120)
   {
     return false;
   }

--- a/TemperatureSensors.cpp
+++ b/TemperatureSensors.cpp
@@ -32,71 +32,60 @@ void TemperatureSensors::RequestTemperatures()
   this->sensors->requestTemperatures();
 }
 
-void TemperatureSensors::GetAcumulator1Temperature(uint8_t* temperature)
+bool TemperatureSensors::GetAcumulator1Temperature(uint8_t* temperature)
 {
-  GetTemperature(acumulatorFirst, temperature);
+  return GetTemperature(acumulatorFirst, temperature);
 }
 
-void TemperatureSensors::GetAcumulator2Temperature(uint8_t* temperature)
+bool TemperatureSensors::GetAcumulator2Temperature(uint8_t* temperature)
 {
-  GetTemperature(acumulatorSecond, temperature);
+  return GetTemperature(acumulatorSecond, temperature);
 }
 
-void TemperatureSensors::GetAcumulator3Temperature(uint8_t* temperature)
+bool TemperatureSensors::GetAcumulator3Temperature(uint8_t* temperature)
 {
-  GetTemperature(acumulatorThird, temperature);
+  return GetTemperature(acumulatorThird, temperature);
 }
 
-void TemperatureSensors::GetAcumulator4Temperature(uint8_t* temperature)
+bool TemperatureSensors::GetAcumulator4Temperature(uint8_t* temperature)
 {
-  GetTemperature(acumulatorFour, temperature);
+  return GetTemperature(acumulatorFour, temperature);
 }
 
-void TemperatureSensors::GetAcumulatorOutputTemperature(uint8_t* temperature)
+bool TemperatureSensors::GetAcumulatorOutputTemperature(uint8_t* temperature)
 {
-  GetTemperature(acumulatorOutput, temperature);
+  return GetTemperature(acumulatorOutput, temperature);
 }
 
-void TemperatureSensors::GetReturnHeatingTemperature(uint8_t* temperature)
+bool TemperatureSensors::GetReturnHeatingTemperature(uint8_t* temperature)
 {
-  GetTemperature(returnHeating, temperature);
+  return GetTemperature(returnHeating, temperature);
 }
 
-void TemperatureSensors::GetHeaterTemperature(uint8_t* temperature)
+bool TemperatureSensors::GetHeaterTemperature(uint8_t* temperature)
 {
-  GetTemperature(heaterTemperature, temperature);
+  return GetTemperature(heaterTemperature, temperature);
 }
 
-void TemperatureSensors::GetBoilerTemperature(uint8_t* temperature)
+bool TemperatureSensors::GetBoilerTemperature(uint8_t* temperature)
 {
-  GetTemperature(boiler, temperature);
+  return GetTemperature(boiler, temperature);
 }
 
-void TemperatureSensors::GetCurrentHeatingTemperature(uint8_t* temperature)
+bool TemperatureSensors::GetCurrentHeatingTemperature(uint8_t* temperature)
 {
-  GetTemperature(currentHeating, temperature);
+  return GetTemperature(currentHeating, temperature);
 }
 
-void TemperatureSensors::GetTemperature(DeviceAddress deviceAddress, uint8_t* temperature)
+bool TemperatureSensors::GetTemperature(DeviceAddress deviceAddress, uint8_t* temperature)
 {
   float temp = sensors->getTempC(deviceAddress);
-  if(temp == -127)
+  if(temp <= -127.0f || temp < 0 || temp > 120)
   {
-    return;
-  }
-  if(temp == -254)
-  {
-    return;
-  }
-  if(temp == -253)
-  {
-    return;
-  }
-  if(temp == -252)
-  {
-    return;
+    return false;
   }
   *temperature = (uint8_t)round(temp);
+  return true;
 }
 
 void TemperatureSensors::PrintAddress(DeviceAddress deviceAddress)

--- a/TemperatureSensors.h
+++ b/TemperatureSensors.h
@@ -9,18 +9,18 @@ class TemperatureSensors
     OneWire* oneWire;
     DallasTemperature* sensors;
     void PrintAddress(DeviceAddress deviceAddress);
-    void GetTemperature(DeviceAddress deviceAddress, uint8_t* temperature);
+    bool GetTemperature(DeviceAddress deviceAddress, uint8_t* temperature);
   public:
     TemperatureSensors(uint8_t busPin);
-    void GetAcumulator1Temperature(uint8_t* temperature);
-    void GetAcumulator2Temperature(uint8_t* temperature);
-    void GetAcumulator3Temperature(uint8_t* temperature);
-    void GetAcumulator4Temperature(uint8_t* temperature);
-    void GetAcumulatorOutputTemperature(uint8_t* temperature);
-    void GetReturnHeatingTemperature(uint8_t* temperature);
-    void GetCurrentHeatingTemperature(uint8_t* temperature);
-    void GetHeaterTemperature(uint8_t* temperature);
-    void GetBoilerTemperature(uint8_t* temperature);
+    bool GetAcumulator1Temperature(uint8_t* temperature);
+    bool GetAcumulator2Temperature(uint8_t* temperature);
+    bool GetAcumulator3Temperature(uint8_t* temperature);
+    bool GetAcumulator4Temperature(uint8_t* temperature);
+    bool GetAcumulatorOutputTemperature(uint8_t* temperature);
+    bool GetReturnHeatingTemperature(uint8_t* temperature);
+    bool GetCurrentHeatingTemperature(uint8_t* temperature);
+    bool GetHeaterTemperature(uint8_t* temperature);
+    bool GetBoilerTemperature(uint8_t* temperature);
     void Init();
     void RequestTemperatures();
 };

--- a/config_default.h
+++ b/config_default.h
@@ -16,6 +16,7 @@
 #define TOPIC_HEATERSTATE "TOPIC_HEATERSTATE"
 #define TOPIC_FVE "TOPIC_FVE"
 #define TOPIC_FVE_STATE "TOPIC_FVE_STATE"
+#define TOPIC_DIAG "TOPIC_DIAG"
 
 #define MAXTEMPDIFFERENCE 0
 #define PCONST            0  //P konstanta pro PID


### PR DESCRIPTION
Introduce runtime diagnostics and propagate sensor failures. Adds DiagData struct, TOPIC_DIAG config, freeRam() helper and tracking of wifi/mqtt reconnect counts and max loop time. Diag data (uptime, free RAM, reconnect counters, max loop ms, sensor error bitmap, reset reason) is published periodically to TOPIC_DIAG and reset where appropriate. Temperature sensor getters now return bool and Validate temperature readings; callers mark bits in sensorErr when reads fail. Also record MCUSR reset reason on startup and measure loop execution time. These changes improve observability of sensor faults and system health.